### PR TITLE
ROS Ntrip Version Configuration

### DIFF
--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -10,6 +10,7 @@
   <arg name="authenticate"           default = "true" />
   <arg name="username"               default = "user" />
   <arg name="password"               default = "pass" />
+  <arg name="ntrip_version"          default = "" />
 
   <!-- ****************************************************************** -->
   <!-- NTRIP Client Node -->
@@ -20,6 +21,9 @@
     <param name="host"       value="$(arg host)" />
     <param name="port"       value="$(arg port)" />
     <param name="mountpoint" value="$(arg mountpoint)" />
+
+    <!-- Optional parameter that will set the NTRIP version in the initial HTTP request to the NTRIP caster. -->
+    <param name="ntrip_version" value="$(arg ntrip_version)" />
 
     <!-- If this is set to true, we will read the username and password and attempt to authenticate. If not, we will attempt to connect unauthenticated -->
     <param name="authenticate" value="$(arg authenticate)" />

--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -11,6 +11,10 @@
   <arg name="username"               default = "user" />
   <arg name="password"               default = "pass" />
   <arg name="ntrip_version"          default = "" />
+  <arg name="debug"                  default = "false" />
+
+  <!-- Set the log level to debug -->
+  <env name="NTRIP_CLIENT_DEBUG" value="$(arg debug)" />
 
   <!-- ****************************************************************** -->
   <!-- NTRIP Client Node -->

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+import os
 import sys
+import json
 
 import rospy
 from std_msgs.msg import Header
@@ -12,8 +14,17 @@ from ntrip_client.ntrip_client import NTRIPClient
 
 class NTRIPRos:
   def __init__(self):
+    # Read a debug flag from the environment that should have been set by the launch file
+    try:
+      self._debug = json.loads(os.environ["NTRIP_CLIENT_DEBUG"].lower())
+    except:
+      self._debug = False
+
     # Init the node and read some mandatory config
-    rospy.init_node('ntrip_client', anonymous=True)
+    if self._debug:
+      rospy.init_node('ntrip_client', anonymous=True, log_level=rospy.DEBUG)
+    else:
+      rospy.init_node('ntrip_client', anonymous=True)
     host = rospy.get_param('~host', '127.0.0.1')
     port = rospy.get_param('~port', '2101')
     mountpoint = rospy.get_param('~mountpoint', 'mount')

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -18,6 +18,11 @@ class NTRIPRos:
     port = rospy.get_param('~port', '2101')
     mountpoint = rospy.get_param('~mountpoint', 'mount')
 
+    # Optionally get the ntrip version from the launch file
+    ntrip_version = rospy.get_param('~ntrip_version', None)
+    if ntrip_version == '':
+      ntrip_version = None
+
     # If we were asked to authenticate, read the username and password
     username = None
     password = None
@@ -45,6 +50,7 @@ class NTRIPRos:
       host=host,
       port=port,
       mountpoint=mountpoint,
+      ntrip_version=ntrip_version,
       username=username,
       password=password,
       logerr=rospy.logerr,


### PR DESCRIPTION
* No longer sends an `Ntrip-Version` header with no value
* Allows the user to specify an `ntrip_version` which will be sent as the `Ntrip-Version` header value