### PR TITLE
ROS2 Ntrip Version Configuration

### DIFF
--- a/launch/ntrip_client_launch.py
+++ b/launch/ntrip_client_launch.py
@@ -2,51 +2,56 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch.substitutions import EnvironmentVariable
+from launch.actions import SetEnvironmentVariable
 
 def generate_launch_description():
       return LaunchDescription([
-            # Declare arguments with default values
-            DeclareLaunchArgument('host',          default_value='20.185.11.35'),
-            DeclareLaunchArgument('port',          default_value='2101'),
-            DeclareLaunchArgument('mountpoint',    default_value='VTRI_RTCM3'),
-            DeclareLaunchArgument('ntrip_version', default_value=''),
-            DeclareLaunchArgument('authenticate',  default_value='True'),
-            DeclareLaunchArgument('username',      default_value='user'),
-            DeclareLaunchArgument('password',      default_value='pass'),
+          # Declare arguments with default values
+          DeclareLaunchArgument('host',          default_value='20.185.11.35'),
+          DeclareLaunchArgument('port',          default_value='2101'),
+          DeclareLaunchArgument('mountpoint',    default_value='VTRI_RTCM3'),
+          DeclareLaunchArgument('ntrip_version', default_value=''),
+          DeclareLaunchArgument('authenticate',  default_value='True'),
+          DeclareLaunchArgument('username',      default_value='user'),
+          DeclareLaunchArgument('password',      default_value='pass'),
+          DeclareLaunchArgument('debug',         default_value='false'),
 
-           # ****************************************************************** 
-           # NTRIP Client Node
-           # ****************************************************************** 
-           Node(
-                 name='ntrip_client_node',
-                 namespace='ntrip_client',
-                 package='ntrip_client',
-                 executable='ntrip_ros.py',
-                 parameters=[
-                   {
-                     # Required parameters used to connect to the NTRIP server
-                     'host': LaunchConfiguration('host'),
-                     'port': LaunchConfiguration('port'),
-                     'mountpoint': LaunchConfiguration('mountpoint'),
+          # Pass an environment variable to the node
+          SetEnvironmentVariable(name='NTRIP_CLIENT_DEBUG', value=LaunchConfiguration('debug')),
 
-                     # Optional parameter that will set the NTRIP version in the initial HTTP request to the NTRIP caster.
-                     'ntrip_version': LaunchConfiguration('ntrip_version'),
+          # ****************************************************************** 
+          # NTRIP Client Node
+          # ****************************************************************** 
+          Node(
+                name='ntrip_client_node',
+                namespace='ntrip_client',
+                package='ntrip_client',
+                executable='ntrip_ros.py',
+                parameters=[
+                  {
+                    # Required parameters used to connect to the NTRIP server
+                    'host': LaunchConfiguration('host'),
+                    'port': LaunchConfiguration('port'),
+                    'mountpoint': LaunchConfiguration('mountpoint'),
 
-                     # If this is set to true, we will read the username and password and attempt to authenticate. If not, we will attempt to connect unauthenticated
-                     'authenticate': LaunchConfiguration('authenticate'),
+                    # Optional parameter that will set the NTRIP version in the initial HTTP request to the NTRIP caster.
+                    'ntrip_version': LaunchConfiguration('ntrip_version'),
 
-                     # If authenticate is set the true, we will use these to authenticate with the server
-                     'username': LaunchConfiguration('username'),
-                     'password': LaunchConfiguration('password'),
+                    # If this is set to true, we will read the username and password and attempt to authenticate. If not, we will attempt to connect unauthenticated
+                    'authenticate': LaunchConfiguration('authenticate'),
 
-                     # Not sure if this will be looked at by other ndoes, but this frame ID will be added to the RTCM messages published by this node
-                     'rtcm_frame_id': 'odom'
-                   }
-                 ],
-                 # Uncomment the following section and replace "/gq7/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested
-                #  remappings=[
-                #    ("/ntrip_client/nmea", "/gx5/nmea/sentence")
-                #  ],
-                #  
-           )
+                    # If authenticate is set the true, we will use these to authenticate with the server
+                    'username': LaunchConfiguration('username'),
+                    'password': LaunchConfiguration('password'),
+
+                    # Not sure if this will be looked at by other ndoes, but this frame ID will be added to the RTCM messages published by this node
+                    'rtcm_frame_id': 'odom'
+                  }
+                ],
+                # Uncomment the following section and replace "/gq7/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested
+                #remappings=[
+                #  ("/ntrip_client/nmea", "/gx5/nmea/sentence")
+                #],
+          )
       ])

--- a/launch/ntrip_client_launch.py
+++ b/launch/ntrip_client_launch.py
@@ -6,12 +6,13 @@ from launch_ros.actions import Node
 def generate_launch_description():
       return LaunchDescription([
             # Declare arguments with default values
-            DeclareLaunchArgument('host',         default_value='20.185.11.35'),
-            DeclareLaunchArgument('port',         default_value='2101'),
-            DeclareLaunchArgument('mountpoint',   default_value='VTRI_RTCM3'),
-            DeclareLaunchArgument('authenticate', default_value='True'),
-            DeclareLaunchArgument('username',     default_value='user'),
-            DeclareLaunchArgument('password',     default_value='pass'),
+            DeclareLaunchArgument('host',          default_value='20.185.11.35'),
+            DeclareLaunchArgument('port',          default_value='2101'),
+            DeclareLaunchArgument('mountpoint',    default_value='VTRI_RTCM3'),
+            DeclareLaunchArgument('ntrip_version', default_value=''),
+            DeclareLaunchArgument('authenticate',  default_value='True'),
+            DeclareLaunchArgument('username',      default_value='user'),
+            DeclareLaunchArgument('password',      default_value='pass'),
 
            # ****************************************************************** 
            # NTRIP Client Node
@@ -27,6 +28,9 @@ def generate_launch_description():
                      'host': LaunchConfiguration('host'),
                      'port': LaunchConfiguration('port'),
                      'mountpoint': LaunchConfiguration('mountpoint'),
+
+                     # Optional parameter that will set the NTRIP version in the initial HTTP request to the NTRIP caster.
+                     'ntrip_version': LaunchConfiguration('ntrip_version'),
 
                      # If this is set to true, we will read the username and password and attempt to authenticate. If not, we will attempt to connect unauthenticated
                      'authenticate': LaunchConfiguration('authenticate'),

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -21,6 +21,7 @@ class NTRIPRos(Node):
         ('host', '127.0.0.1'),
         ('port', 2101),
         ('mountpoint', 'mount'),
+        ('ntrip_version', ''),
         ('authenticate', False),
         ('username', ''),
         ('password', ''),
@@ -32,6 +33,11 @@ class NTRIPRos(Node):
     host = self.get_parameter('host').value
     port = self.get_parameter('port').value
     mountpoint = self.get_parameter('mountpoint').value
+
+    # Optionally get the ntrip version from the launch file
+    ntrip_version = self.get_parameter('ntrip_version').value
+    if ntrip_version == '':
+      ntrip_version = None
 
     # If we were asked to authenticate, read the username and password
     username = None
@@ -59,6 +65,7 @@ class NTRIPRos(Node):
       host=host,
       port=port,
       mountpoint=mountpoint,
+      ntrip_version=ntrip_version,
       username=username,
       password=password,
       logerr=self.get_logger().error,

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+import os
 import sys
+import json
 
 import rclpy
 from rclpy.node import Node
@@ -13,6 +15,12 @@ from ntrip_client.ntrip_client import NTRIPClient
 
 class NTRIPRos(Node):
   def __init__(self):
+    # Read a debug flag from the environment that should have been set by the launch file
+    try:
+      self._debug = json.loads(os.environ["NTRIP_CLIENT_DEBUG"].lower())
+    except:
+      self._debug = False
+
     # Init the node and declare params
     super().__init__('ntrip_client')
     self.declare_parameters(
@@ -38,6 +46,10 @@ class NTRIPRos(Node):
     ntrip_version = self.get_parameter('ntrip_version').value
     if ntrip_version == '':
       ntrip_version = None
+
+    # Set the log level to debug if debug is true
+    if self._debug:
+      rclpy.logging.set_logger_level(self.get_logger().name, rclpy.logging.LoggingSeverity.DEBUG)
 
     # If we were asked to authenticate, read the username and password
     username = None


### PR DESCRIPTION
* No longer sends an `Ntrip-Version` header with no value
* Allows the user to specify an `ntrip_version` which will be sent as the `Ntrip-Version` header value