### PR TITLE
Fix for empty default param problem

### DIFF
--- a/launch/ntrip_client_launch.py
+++ b/launch/ntrip_client_launch.py
@@ -11,7 +11,7 @@ def generate_launch_description():
           DeclareLaunchArgument('host',          default_value='20.185.11.35'),
           DeclareLaunchArgument('port',          default_value='2101'),
           DeclareLaunchArgument('mountpoint',    default_value='VTRI_RTCM3'),
-          DeclareLaunchArgument('ntrip_version', default_value=''),
+          DeclareLaunchArgument('ntrip_version', default_value='None'),
           DeclareLaunchArgument('authenticate',  default_value='True'),
           DeclareLaunchArgument('username',      default_value='user'),
           DeclareLaunchArgument('password',      default_value='pass'),

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -29,7 +29,7 @@ class NTRIPRos(Node):
         ('host', '127.0.0.1'),
         ('port', 2101),
         ('mountpoint', 'mount'),
-        ('ntrip_version', ''),
+        ('ntrip_version', 'None'),
         ('authenticate', False),
         ('username', ''),
         ('password', ''),
@@ -44,7 +44,7 @@ class NTRIPRos(Node):
 
     # Optionally get the ntrip version from the launch file
     ntrip_version = self.get_parameter('ntrip_version').value
-    if ntrip_version == '':
+    if ntrip_version == 'None':
       ntrip_version = None
 
     # Set the log level to debug if debug is true


### PR DESCRIPTION
ROS2 foxy and above seems to take issue with default parameters set to empty strings (see https://github.com/introlab/rtabmap_ros/issues/725). This PR addresses that problem for `ntrip_version` by giving it a default value of `'None'` and adjusting checks appropriately.