### PR TITLE
ROS2 automatic reconnect

### DIFF
--- a/.devcontainer/.vscode-docker/settings.json
+++ b/.devcontainer/.vscode-docker/settings.json
@@ -1,11 +1,13 @@
 {
     "python.autoComplete.extraPaths": [
+        "/home/microstrain/catkin_ws/src/ntrip_client/src",
         "/home/microstrain/catkin_ws/devel/lib/python3/dist-packages",
         "/home/microstrain/catkin_ws/devel/lib/python2.7/dist-packages",
         "/opt/ros/noetic/lib/python3/dist-packages",
         "/opt/ros/melodic/lib/python2.7/dist-packages"
     ],
     "python.analysis.extraPaths": [
+        "/home/microstrain/catkin_ws/src/ntrip_client/src",
         "/home/microstrain/catkin_ws/devel/lib/python3/dist-packages",
         "/home/microstrain/catkin_ws/devel/lib/python2.7/dist-packages",
         "/opt/ros/noetic/lib/python3/dist-packages",

--- a/launch/ntrip_client_launch.py
+++ b/launch/ntrip_client_launch.py
@@ -46,7 +46,14 @@ def generate_launch_description():
                     'password': LaunchConfiguration('password'),
 
                     # Not sure if this will be looked at by other ndoes, but this frame ID will be added to the RTCM messages published by this node
-                    'rtcm_frame_id': 'odom'
+                    'rtcm_frame_id': 'odom',
+
+                    # Will affect how many times the node will attempt to reconnect before exiting, and how long it will wait in between attempts when a reconnect occurs
+                    'reconnect_attempt_max': 10,
+                    'reconnect_attempt_wait_seconds': 5,
+
+                    # How many seconds is acceptable in between receiving RTCM. If RTCM is not received for this duration, the node will attempt to reconnect
+                    'rtcm_timeout_seconds': 4
                   }
                 ],
                 # Uncomment the following section and replace "/gq7/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -33,7 +33,10 @@ class NTRIPRos(Node):
         ('authenticate', False),
         ('username', ''),
         ('password', ''),
-        ('rtcm_frame_id', 'odom')
+        ('rtcm_frame_id', 'odom'),
+        ('reconnect_attempt_max', 10),
+        ('reconnect_attempt_wait_seconds', 5),
+        ('rtcm_timeout_seconds', 4),
       ]
     )
 
@@ -69,8 +72,13 @@ class NTRIPRos(Node):
     # Read an optional Frame ID from the config
     self._rtcm_frame_id = self.get_parameter('rtcm_frame_id').value
 
+    # Get some timeout parameters for the NTRIP client
+    reconnect_attempt_max = self.get_parameter('reconnect_attempt_max').value
+    reconnect_attempt_wait_seconds = self.get_parameter('reconnect_attempt_wait_seconds').value
+    rtcm_timeout_seconds = self.get_parameter('rtcm_timeout_seconds').value
+
     # Setup the RTCM publisher
-    self._rtcm_pub = self.create_publisher(RTCM, 'rtcm', 10)
+    self._rtcm_pub = self.create_publisher(Sentence, 'rtcm', 10)
 
     # Initialize the client
     self._client = NTRIPClient(
@@ -80,6 +88,9 @@ class NTRIPRos(Node):
       ntrip_version=ntrip_version,
       username=username,
       password=password,
+      reconnect_attempt_max=reconnect_attempt_max,
+      reconnect_attempt_wait_seconds=reconnect_attempt_wait_seconds,
+      rtcm_timeout_seconds=rtcm_timeout_seconds,
       logerr=self.get_logger().error,
       logwarn=self.get_logger().warning,
       loginfo=self.get_logger().info,
@@ -114,6 +125,8 @@ class NTRIPRos(Node):
 
   def publish_rtcm(self):
     for raw_rtcm in self._client.recv_rtcm():
+      pass
+      '''
       self._rtcm_pub.publish(RTCM(
         header=Header(
           stamp=self.get_clock().now().to_msg(),
@@ -121,6 +134,7 @@ class NTRIPRos(Node):
         ),
         data=raw_rtcm
       ))
+      '''
 
 
 if __name__ == '__main__':

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -34,9 +34,9 @@ class NTRIPRos(Node):
         ('username', ''),
         ('password', ''),
         ('rtcm_frame_id', 'odom'),
-        ('reconnect_attempt_max', 10),
-        ('reconnect_attempt_wait_seconds', 5),
-        ('rtcm_timeout_seconds', 4),
+        ('reconnect_attempt_max', NTRIPClient.DEFAULT_RECONNECT_ATTEMPT_MAX),
+        ('reconnect_attempt_wait_seconds', NTRIPClient.DEFAULT_RECONNECT_ATEMPT_WAIT_SECONDS),
+        ('rtcm_timeout_seconds', NTRIPClient.DEFAULT_RTCM_TIMEOUT_SECONDS),
       ]
     )
 
@@ -88,14 +88,16 @@ class NTRIPRos(Node):
       ntrip_version=ntrip_version,
       username=username,
       password=password,
-      reconnect_attempt_max=reconnect_attempt_max,
-      reconnect_attempt_wait_seconds=reconnect_attempt_wait_seconds,
-      rtcm_timeout_seconds=rtcm_timeout_seconds,
       logerr=self.get_logger().error,
       logwarn=self.get_logger().warning,
       loginfo=self.get_logger().info,
       logdebug=self.get_logger().debug
     )
+
+    # Set parameters on the client
+    self._client.reconnect_attempt_max = reconnect_attempt_max
+    self._client.reconnect_attempt_wait_seconds = reconnect_attempt_wait_seconds
+    self._client.rtcm_timeout_seconds = rtcm_timeout_seconds
 
   def run(self):
     # Connect the client

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -78,7 +78,7 @@ class NTRIPRos(Node):
     rtcm_timeout_seconds = self.get_parameter('rtcm_timeout_seconds').value
 
     # Setup the RTCM publisher
-    self._rtcm_pub = self.create_publisher(Sentence, 'rtcm', 10)
+    self._rtcm_pub = self.create_publisher(RTCM, 'rtcm', 10)
 
     # Initialize the client
     self._client = NTRIPClient(

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -125,8 +125,6 @@ class NTRIPRos(Node):
 
   def publish_rtcm(self):
     for raw_rtcm in self._client.recv_rtcm():
-      pass
-      '''
       self._rtcm_pub.publish(RTCM(
         header=Header(
           stamp=self.get_clock().now().to_msg(),
@@ -134,7 +132,6 @@ class NTRIPRos(Node):
         ),
         data=raw_rtcm
       ))
-      '''
 
 
 if __name__ == '__main__':

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import time
 import base64
 import socket
 import select
@@ -41,8 +42,15 @@ class NTRIPClient:
     else:
       self._basic_credentials = None
 
-    # Create a socket object that we will use to connect to the server
-    self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Reconnect info
+    # TODO(robbiefish): Make these configurable?
+    self._reconnect_attempt_count = 0
+    self._reconnect_attempt_max = 10
+    self._reconnect_attempt_wait_seconds = 5
+    self._nmea_send_failed_count = 0
+    self._nmea_send_failed_max = 3
+    self._read_zero_bytes_count = 0
+    self._read_zero_bytes_max = 5
 
     # Setup some parsers to parse incoming messages
     self._rtcm_parser = RTCMParser(
@@ -62,6 +70,10 @@ class NTRIPClient:
     self._connected = False
 
   def connect(self):
+    # Create a socket object that we will use to connect to the server
+    self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    self._server_socket.settimeout(5)
+
     # Connect the socket to the server
     try:
       self._server_socket.connect((self._host, self._port))
@@ -92,7 +104,6 @@ class NTRIPClient:
 
     # Properly handle the response
     if any(success in response for success in _SUCCESS_RESPONSES):
-      self._server_socket.setblocking(False)
       self._connected = True
 
     # Some debugging hints about the kind of error we received
@@ -122,8 +133,36 @@ class NTRIPClient:
 
   def disconnect(self):
     # Disconnect the socket
-    self._server_socket.close()
     self._connected = False
+    try:
+      self._server_socket.shutdown(socket.SHUT_RDWR)
+    except Exception as e:
+      self._logdebug('Encountered exception when shutting down the socket. This can likely be ignored')
+      self._logdebug('Exception: {}'.format(e))
+    try:
+      self._server_socket.close()
+    except Exception as e:
+      self._logdebug('Encountered exception when closing the socket. This can likely be ignored')
+      self._logdebug('Exception: {}'.format(e))
+    
+  def reconnect(self):
+    if self._connected:
+      while True:
+        self._reconnect_attempt_count += 1
+        self.disconnect()
+        connect_success = self.connect()
+        if not connect_success and self._reconnect_attempt_count < self._reconnect_attempt_max:
+          self._logerr('Reconnect to http://{}:{} failed. Retrying in {} seconds'.format(self._host, self._port, self._reconnect_attempt_wait_seconds))
+          time.sleep(self._reconnect_attempt_wait_seconds)
+        elif self._reconnect_attempt_count >= self._reconnect_attempt_max:
+          self._reconnect_attempt_count = 0
+          raise Exception("Reconnect was attempted {} times, but never succeeded".format(self._reconnect_attempt_count))
+          break
+        elif connect_success:
+          self._reconnect_attempt_count = 0
+          break
+    else:
+      self._logdebug('Reconnect called while still connected, ignoring')
 
   def send_nmea(self, sentence):
     if not self._connected:
@@ -147,6 +186,12 @@ class NTRIPClient:
     except Exception as e:
       self._logwarn('Unable to send NMEA sentence to server.')
       self._logwarn('Exception: {}'.format(str(e)))
+      self._nmea_send_failed_count += 1
+      if self._nmea_send_failed_count >= self._nmea_send_failed_max:
+        self._logwarn("NMEA sentence failed to send to server {} times, restarting".format(self._nmea_send_failed_count))
+        self.reconnect()
+        self._nmea_send_failed_count = 0
+
 
   def recv_rtcm(self):
     if not self._connected:
@@ -157,17 +202,39 @@ class NTRIPClient:
     # Check if there is any data available on the socket
     read_sockets, _, _ = select.select([self._server_socket], [], [], 0)
     if not read_sockets:
+      # Perform a little hack to check if the server side is still connected
+      if not self._socket_is_open():
+        self._logerr('Socket appears to be unusable for some reason, reconnecting')
+        self.reconnect()
       return []
 
     # Since we only ever pass the server socket to the list of read sockets, we can just read from that
     # Read all available data into a buffer
     data = b''
     while True:
-      chunk = self._server_socket.recv(_CHUNK_SIZE)
-      data += chunk
-      if len(chunk) < _CHUNK_SIZE:
+      try:
+        chunk = self._server_socket.recv(_CHUNK_SIZE)
+        data += chunk
+        if len(chunk) < _CHUNK_SIZE:
+          break
+      except Exception as e:
+        self._logerr('Error while reading {} bytes from socket'.format(_CHUNK_SIZE))
+        if not self._socket_is_open():
+          self._logerr('Socket appears to be closed. Reconnecting')
+          self.reconnect()
+          return []
         break
     self._logdebug('Read {} bytes'.format(len(data)))
+
+    # If 0 bytes were read from the socket even though we were told data is available multiple times,
+    # it can be safely assumed that we can reconnect as the server has closed the connection
+    if len(data) == 0:
+      self._read_zero_bytes_count += 1
+      if self._read_zero_bytes_count >= self._read_zero_bytes_max:
+        self._logwarn('Reconnecting because we received 0 bytes from the socket even though it said there was data available {} times'.format(self._read_zero_bytes_count))
+        self.reconnect()
+        self._read_zero_bytes_count = 0
+        return []
 
     # Send the data to the RTCM parser to parse it
     return self._rtcm_parser.parse(data) if data else []
@@ -184,3 +251,19 @@ class NTRIPClient:
         self._basic_credentials)
     request_str += '\r\n'
     return request_str.encode('utf-8')
+  
+  def _socket_is_open(self):
+    try:
+      # this will try to read bytes without blocking and also without removing them from buffer (peek only)
+      data = self._server_socket.recv(_CHUNK_SIZE, socket.MSG_DONTWAIT | socket.MSG_PEEK)
+      if len(data) == 0:
+        return False
+    except BlockingIOError:
+      return True  # socket is open and reading from it would block
+    except ConnectionResetError:
+      self._logwarn('Connection reset by peer')
+      return False  # socket was closed for some other reason
+    except Exception as e:
+      self._logwarn('Socket appears to be closed')
+      return False
+    return True


### PR DESCRIPTION
* Automatically reconnects to the NTRIP caster if:
    * RTCM is not received for a configurable amount of time
    * If NMEA fails to be sent to the server
    * If the socket appears to be closed
* Allows the number of reconnect attempts and interval between reconnects to be configured by the launch file