### PR TITLE
ROS2 NMEA sentence min/max length

### DIFF
--- a/launch/ntrip_client_launch.py
+++ b/launch/ntrip_client_launch.py
@@ -47,6 +47,10 @@ def generate_launch_description():
 
                     # Not sure if this will be looked at by other ndoes, but this frame ID will be added to the RTCM messages published by this node
                     'rtcm_frame_id': 'odom'
+
+                    # Optional parameters that will allow for longer or shorter NMEA messages. Standard max length for NMEA is 82
+                    'nmea_max_length': 82,
+                    'nmea_min_length': 3,
                   }
                 ],
                 # Uncomment the following section and replace "/gq7/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -11,6 +11,7 @@ from mavros_msgs.msg import RTCM
 from nmea_msgs.msg import Sentence
 
 from ntrip_client.ntrip_client import NTRIPClient
+from ntrip_client.nmea_parser import NMEA_DEFAULT_MAX_LENGTH, NMEA_DEFAULT_MIN_LENGTH
 
 
 class NTRIPRos(Node):
@@ -33,7 +34,9 @@ class NTRIPRos(Node):
         ('authenticate', False),
         ('username', ''),
         ('password', ''),
-        ('rtcm_frame_id', 'odom')
+        ('rtcm_frame_id', 'odom'),
+        ('nmea_max_length', NMEA_DEFAULT_MAX_LENGTH),
+        ('nmea_min_length', NMEA_DEFAULT_MIN_LENGTH),
       ]
     )
 
@@ -69,6 +72,10 @@ class NTRIPRos(Node):
     # Read an optional Frame ID from the config
     self._rtcm_frame_id = self.get_parameter('rtcm_frame_id').value
 
+    # Read some options for parsing NMEA from the launch file
+    nmea_max_length = self.get_parameter('nmea_max_length').value
+    nmea_min_length = self.get_parameter('nmea_min_length').value
+
     # Setup the RTCM publisher
     self._rtcm_pub = self.create_publisher(RTCM, 'rtcm', 10)
 
@@ -85,6 +92,10 @@ class NTRIPRos(Node):
       loginfo=self.get_logger().info,
       logdebug=self.get_logger().debug
     )
+
+    # Set parameters on the client
+    self._client.nmea_parser.nmea_max_length = nmea_max_length
+    self._client.nmea_parser.nmea_min_length = nmea_min_length
 
   def run(self):
     # Connect the client

--- a/src/ntrip_client/nmea_parser.py
+++ b/src/ntrip_client/nmea_parser.py
@@ -1,7 +1,7 @@
 import logging
 
-_NMEA_MAX_LENGTH = 82
-_NMEA_MIN_LENGTH = 3
+NMEA_DEFAULT_MAX_LENGTH = 82
+NMEA_DEFAULT_MIN_LENGTH = 3
 _NMEA_CHECKSUM_SEPERATOR = "*"
 
 class NMEAParser:
@@ -13,14 +13,18 @@ class NMEAParser:
     self._loginfo = loginfo
     self._logdebug = logdebug
 
+    # Save some other config
+    self.nmea_max_length = NMEA_DEFAULT_MAX_LENGTH
+    self.nmea_min_length = NMEA_DEFAULT_MIN_LENGTH
+
   def is_valid_sentence(self, sentence):
     # Simple sanity checks
-    if len(sentence) > _NMEA_MAX_LENGTH:
-      self._logwarn('Received invalid NMEA sentence. Max length is {}, but sentence was {} bytes'.format(_NMEA_MAX_LENGTH, len(sentence)))
+    if len(sentence) > self.nmea_max_length:
+      self._logwarn('Received invalid NMEA sentence. Max length is {}, but sentence was {} bytes'.format(self.nmea_max_length, len(sentence)))
       self._logwarn('Sentence: {}'.format(sentence))
       return False
-    if len(sentence) < _NMEA_MIN_LENGTH:
-      self._logwarn('Received invalid NMEA sentence. We need at least {} bytes to parse but got {} bytes'.format(_NMEA_MIN_LENGTH, len(sentence)))
+    if len(sentence) < self.nmea_min_length:
+      self._logwarn('Received invalid NMEA sentence. We need at least {} bytes to parse but got {} bytes'.format(self.nmea_min_length, len(sentence)))
       self._logwarn('Sentence: {}'.format(sentence))
       return False
     if sentence[0] != '$' and sentence[0] != '!':

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -5,7 +5,7 @@ import socket
 import select
 import logging
 
-from .nmea_parser import NMEAParser, NMEA_DEFAULT_MAX_LENGTH, NMEA_DEFAULT_MIN_LENGTH
+from .nmea_parser import NMEAParser
 from .rtcm_parser import RTCMParser
 
 _CHUNK_SIZE = 1024

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -5,7 +5,7 @@ import socket
 import select
 import logging
 
-from .nmea_parser import NMEAParser
+from .nmea_parser import NMEAParser, NMEA_DEFAULT_MAX_LENGTH, NMEA_DEFAULT_MIN_LENGTH
 from .rtcm_parser import RTCMParser
 
 _CHUNK_SIZE = 1024
@@ -45,13 +45,13 @@ class NTRIPClient:
     self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     # Setup some parsers to parse incoming messages
-    self._rtcm_parser = RTCMParser(
+    self.rtcm_parser = RTCMParser(
       logerr=logerr,
       logwarn=logwarn,
       loginfo=loginfo,
       logdebug=logdebug
     )
-    self._nmea_parser = NMEAParser(
+    self.nmea_parser = NMEAParser(
       logerr=logerr,
       logwarn=logwarn,
       loginfo=loginfo,
@@ -137,7 +137,7 @@ class NTRIPClient:
       sentence = sentence + '\r\n'
 
     # Check if it is a valid NMEA sentence
-    if not self._nmea_parser.is_valid_sentence(sentence):
+    if not self.nmea_parser.is_valid_sentence(sentence):
       self._logwarn("Invalid NMEA sentence, not sending to server")
       return
 
@@ -170,7 +170,7 @@ class NTRIPClient:
     self._logdebug('Read {} bytes'.format(len(data)))
 
     # Send the data to the RTCM parser to parse it
-    return self._rtcm_parser.parse(data) if data else []
+    return self.rtcm_parser.parse(data) if data else []
 
   def _form_request(self):
     if self._ntrip_version != None and self._ntrip_version != '':


### PR DESCRIPTION
* Allows the user to configure different minimum and maximum lengths for NMEA sentences

See #13 for more details