### PR TITLE
ROS Adds ability to publish an rtcm_msgs Message instead of a mavros_msgs RTCM

### DIFF
--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -12,7 +12,7 @@
   <arg name="password"               default = "pass" />
   <arg name="ntrip_version"          default = "" />
   <arg name="debug"                  default = "false" />
-  <arg name="rtcm_msg_pkg"           default = "mavros_msgs" />
+  <arg name="rtcm_message_package"   default = "mavros_msgs" />
 
   <!-- Set the log level to debug -->
   <env name="NTRIP_CLIENT_DEBUG" value="$(arg debug)" />
@@ -41,7 +41,7 @@
     <param name="rtcm_frame_id" value="odom" />
 
     <!-- Use this parameter to change the type of RTCM message published by the node. Defaults to "mavros_msgs", but we also support "rtcm_msgs" -->
-    <param name="rtcm_msg_pkg" value="$(arg rtcm_msg_pkg)" />
+    <param name="rtcm_message_package" value="$(arg rtcm_message_package)" />
 
     <!-- Uncomment the following section and replace "/gx5/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested -->
     <!--<remap from="/ntrip_client/nmea" to="/gx5/nmea/sentence" />-->

--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -12,6 +12,7 @@
   <arg name="password"               default = "pass" />
   <arg name="ntrip_version"          default = "" />
   <arg name="debug"                  default = "false" />
+  <arg name="rtcm_msg_pkg"           default = "mavros_msgs" />
 
   <!-- Set the log level to debug -->
   <env name="NTRIP_CLIENT_DEBUG" value="$(arg debug)" />
@@ -38,6 +39,9 @@
 
     <!-- Not sure if this will be looked at, but this frame ID will be added to the RTCM messages publishe by this node -->
     <param name="rtcm_frame_id" value="odom" />
+
+    <!-- Use this parameter to change the type of RTCM message published by the node. Defaults to "mavros_msgs", but we also support "rtcm_msgs" -->
+    <param name="rtcm_msg_pkg" value="$(arg rtcm_msg_pkg)" />
 
     <!-- Uncomment the following section and replace "/gx5/nmea/sentence" with the topic you are sending NMEA on if it is not the one we requested -->
     <!--<remap from="/ntrip_client/nmea" to="/gx5/nmea/sentence" />-->

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -3,14 +3,25 @@
 import os
 import sys
 import json
+import importlib
 
 import rospy
 from std_msgs.msg import Header
-from mavros_msgs.msg import RTCM
 from nmea_msgs.msg import Sentence
 
 from ntrip_client.ntrip_client import NTRIPClient
 
+# Try to import a couple different types of RTCM messages
+_MAVROS_MSGS_NAME = "mavros_msgs"
+_RTCM_MSGS_NAME = "rtcm_msgs"
+have_mavros_msgs = False
+have_rtcm_msgs = False
+if importlib.util.find_spec(_MAVROS_MSGS_NAME) is not None:
+  have_mavros_msgs = True
+  from mavros_msgs.msg import RTCM as mavros_msgs_RTCM
+if importlib.util.find_spec(_RTCM_MSGS_NAME) is not None:
+  have_rtcm_msgs = True
+  from rtcm_msgs.msg import Message as rtcm_msgs_RTCM
 
 class NTRIPRos:
   def __init__(self):
@@ -52,9 +63,26 @@ class NTRIPRos:
     # Read an optional Frame ID from the config
     self._rtcm_frame_id = rospy.get_param('~rtcm_frame_id', 'odom')
 
+    # Determine the type of RTCM message that will be published
+    rtcm_msgs_pkg = rospy.get_param('~rtcm_msg_pkg', _MAVROS_MSGS_NAME)
+    if rtcm_msgs_pkg == _MAVROS_MSGS_NAME:
+      if have_mavros_msgs:
+        self._rtcm_msg_type = mavros_msgs_RTCM
+        self._create_rtcm_message = self._create_mavros_msgs_rtcm_message
+      else:
+        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_msgs_pkg))
+    elif rtcm_msgs_pkg == _RTCM_MSGS_NAME:
+      if have_rtcm_msgs:
+        self._rtcm_msg_type = rtcm_msgs_RTCM
+        self._create_rtcm_message = self._create_rtcm_msgs_rtcm_message
+      else:
+        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_msgs_pkg))
+    else:
+      rospy.logfatal('The RTCM package {} is not a valid option. Please choose between the following packages {}'.format(rtcm_msgs_pkg, str.join([_MAVROS_MSGS_NAME, _RTCM_MSGS_NAME])))
+
     # Setup the RTCM publisher
     self._rtcm_timer = None
-    self._rtcm_pub = rospy.Publisher('rtcm', RTCM, queue_size=10)
+    self._rtcm_pub = rospy.Publisher('rtcm', self._rtcm_msg_type, queue_size=10)
 
     # Initialize the client
     self._client = NTRIPClient(
@@ -103,13 +131,25 @@ class NTRIPRos:
 
   def publish_rtcm(self, event):
     for raw_rtcm in self._client.recv_rtcm():
-      self._rtcm_pub.publish(RTCM(
-        header=Header(
-          stamp=rospy.Time.now(),
-          frame_id=self._rtcm_frame_id
-        ),
-        data=raw_rtcm
-      ))
+      self._rtcm_pub.publish(self._create_rtcm_message(raw_rtcm))
+
+  def _create_mavros_msgs_rtcm_message(self, rtcm):
+    return mavros_msgs_RTCM(
+      header=Header(
+        stamp=rospy.Time.now(),
+        frame_id=self._rtcm_frame_id
+      ),
+      data=rtcm
+    )
+
+  def _create_rtcm_msgs_rtcm_message(self, rtcm):
+    return rtcm_msgs_RTCM(
+      header=Header(
+        stamp=rospy.Time.now(),
+        frame_id=self._rtcm_frame_id
+      ),
+      message=rtcm
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -64,25 +64,25 @@ class NTRIPRos:
     self._rtcm_frame_id = rospy.get_param('~rtcm_frame_id', 'odom')
 
     # Determine the type of RTCM message that will be published
-    rtcm_msgs_pkg = rospy.get_param('~rtcm_msg_pkg', _MAVROS_MSGS_NAME)
-    if rtcm_msgs_pkg == _MAVROS_MSGS_NAME:
+    rtcm_message_package = rospy.get_param('~rtcm_message_package', _MAVROS_MSGS_NAME)
+    if rtcm_message_package == _MAVROS_MSGS_NAME:
       if have_mavros_msgs:
-        self._rtcm_msg_type = mavros_msgs_RTCM
+        self._rtcm_message_type = mavros_msgs_RTCM
         self._create_rtcm_message = self._create_mavros_msgs_rtcm_message
       else:
-        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_msgs_pkg))
-    elif rtcm_msgs_pkg == _RTCM_MSGS_NAME:
+        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_message_package))
+    elif rtcm_message_package == _RTCM_MSGS_NAME:
       if have_rtcm_msgs:
-        self._rtcm_msg_type = rtcm_msgs_RTCM
+        self._rtcm_message_type = rtcm_msgs_RTCM
         self._create_rtcm_message = self._create_rtcm_msgs_rtcm_message
       else:
-        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_msgs_pkg))
+        rospy.logfatal('The requested RTCM package {} is a valid option, but we were unable to import it. Please make sure you have it installed'.format(rtcm_message_package))
     else:
-      rospy.logfatal('The RTCM package {} is not a valid option. Please choose between the following packages {}'.format(rtcm_msgs_pkg, str.join([_MAVROS_MSGS_NAME, _RTCM_MSGS_NAME])))
+      rospy.logfatal('The RTCM package {} is not a valid option. Please choose between the following packages {}'.format(rtcm_message_package, str.join([_MAVROS_MSGS_NAME, _RTCM_MSGS_NAME])))
 
     # Setup the RTCM publisher
     self._rtcm_timer = None
-    self._rtcm_pub = rospy.Publisher('rtcm', self._rtcm_msg_type, queue_size=10)
+    self._rtcm_pub = rospy.Publisher('rtcm', self._rtcm_message_type, queue_size=10)
 
     # Initialize the client
     self._client = NTRIPClient(


### PR DESCRIPTION
* Adds launch file parameter `rtcm_message_package` which can be specified as one of the following:
    *  `mavros_msgs` to publish a [`mavros_msgs/RTCM`](https://github.com/mavlink/mavros/blob/ros2/mavros_msgs/msg/RTCM.msg)
    * `rtcm_msgs` to publish a [`rtcm_msgs/Message`](https://github.com/tilk/rtcm_msgs/blob/master/msg/Message.msg)