### PR TITLE
Handle NavSatFix NaN value to prevent crashes

### DIFF
--- a/scripts/ntrip_ros_base.py
+++ b/scripts/ntrip_ros_base.py
@@ -4,6 +4,7 @@ import os
 import json
 import datetime
 import importlib.util
+from math import isnan
 
 import rclpy
 from rclpy.node import Node
@@ -129,17 +130,21 @@ class NTRIPRosBase(Node):
     millisecond = int(time.microsecond * 1e-4)
     nmea_utc = f"{hour:02}{minute:02}{second:02}.{millisecond:02}"
 
+    # Handle NaN
+    latitude_nan = True if isnan(fix.latitude) else False
+    longitude_nan = True if isnan(fix.longitude) else False
+
     # Figure out the direction of the latitude and longitude
     nmea_lat_direction = "N"
     nmea_lon_direction = "E"
-    if fix.latitude < 0:
+    if latitude_nan is False and fix.latitude < 0:
       nmea_lat_direction = "S"
-    if fix.longitude < 0:
+    if longitude_nan is False and fix.longitude < 0:
       nmea_lon_direction = "W"
     
     # Convert the units of the latitude and longitude
-    nmea_lat = NMEAParser.lat_dd_to_dmm(fix.latitude)
-    nmea_lon = NMEAParser.lon_dd_to_dmm(fix.longitude)
+    nmea_lat = NMEAParser.lat_dd_to_dmm(fix.latitude) if latitude_nan is False else 0
+    nmea_lon = NMEAParser.lon_dd_to_dmm(fix.longitude) if longitude_nan is False else 0
 
     # Convert the GPS quality to the right format for the sentence
     status = fix.status.status
@@ -153,7 +158,12 @@ class NTRIPRosBase(Node):
       nmea_status = 0
 
     # Assemble the sentence
-    nmea_sentence_no_checksum = f"$GPGGA,{nmea_utc},{nmea_lat},{nmea_lat_direction},{nmea_lon},{nmea_lon_direction},{nmea_status},05,1.0,100.0,M,-32.0,M,,0000"
+    nmea_sentence_no_checksum = (
+      f"$GPGGA,{nmea_utc},"
+      + (f"{nmea_lat},{nmea_lat_direction}," if latitude_nan is False else ",,")
+      + (f"{nmea_lon},{nmea_lon_direction}," if longitude_nan is False else ",,")
+      + f"{nmea_status},05,1.0,100.0,M,-32.0,M,,0000"
+    )
     nmea_checksum = NMEAParser.checksum(nmea_sentence_no_checksum)
     nmea_sentence = f"{nmea_sentence_no_checksum}*{nmea_checksum:x}\r\n"
 


### PR DESCRIPTION
## Intro
When valid latitude, longitude, or altitude data isn’t received from the GPS (particularly immediately after powering on the GPS module), the NavSatFix message’s latitude and longitude fields may show up as NaN.

- raw NMEA data
  ``` bash
  max@maxbuntu:~$ ros2 topic echo /nmea_sentence 
  header:
    stamp:
      sec: 1745471433
      nanosec: 870266565
    frame_id: gps_link
  sentence: $GNGGA,051033.85,,,,,0,00,9999.0,,,,,,*41
  ```

- NavSatFix data
  ``` bash
  max@maxbuntu:~$ ros2 topic echo /fix
  header:
    stamp:
      sec: 1745471433
      nanosec: 870266565
    frame_id: gps_link
  status:
    status: -1
    service: 1
  latitude: .nan
  longitude: .nan
  altitude: .nan
  position_covariance:
  - 9.9980001e+19
  - 0.0
  - 0.0
  - 0.0
  - 9.9980001e+19
  - 0.0
  - 0.0
  - 0.0
  - 1.599680016e+21
  ```

In this situation, the following error occurs in the NTRIP client:
- ntrip_client
  ``` bash
  max@maxbuntu:~$ ros2 run ntrip_client ntrip_ros.py
  [ntrip_ros.py-3] [INFO] [1745463164.704517554] [ntrip_client]: Stopping RTCM publisher
  [ntrip_ros.py-3] [INFO] [1745463164.706382404] [ntrip_client]: Disconnecting NTRIP client
  [ntrip_ros.py-3] [INFO] [1745463164.708415831] [ntrip_client]: Shutting down node
  [ntrip_ros.py-3] Traceback (most recent call last):
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/ntrip_client/ntrip_ros.py", line 102, in <module>
  [ntrip_ros.py-3]     raise e
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/ntrip_client/ntrip_ros.py", line 98, in <module>
  [ntrip_ros.py-3]     rclpy.spin(node)
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/__init__.py", line 244, in spin
  [ntrip_ros.py-3]     executor.spin_once()
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 827, in spin_once
  [ntrip_ros.py-3]     self._spin_once_impl(timeout_sec)
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 822, in _spin_once_impl
  [ntrip_ros.py-3]     raise handler.exception()
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/task.py", line 239, in __call__
  [ntrip_ros.py-3]     self._handler.send(None)
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 508, in handler
  [ntrip_ros.py-3]     await call_coroutine()
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 396, in _execute
  [ntrip_ros.py-3]     await await_or_execute(sub.callback, *msg_tuple)
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 111, in await_or_execute
  [ntrip_ros.py-3]     return callback(*args)
  [ntrip_ros.py-3]            ^^^^^^^^^^^^^^^
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/ntrip_client/ntrip_ros_base.py", line 141, in subscribe_fix
  [ntrip_ros.py-3]     nmea_lat = NMEAParser.lat_dd_to_dmm(fix.latitude)
  [ntrip_ros.py-3]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [ntrip_ros.py-3]   File "/opt/ros/jazzy/lib/python3.12/site-packages/ntrip_client/nmea_parser.py", line 33, in lat_dd_to_dmm
  [ntrip_ros.py-3]     degrees = int(decimal_degrees_whole)
  [ntrip_ros.py-3]               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  [ntrip_ros.py-3] ValueError: cannot convert float NaN to integer
  [ERROR] [ntrip_ros.py-3]: process has died [pid 3609, exit code 1, cmd '/opt/ros/jazzy/lib/ntrip_client/ntrip_ros.py --ros-args -r __node:=ntrip_client -r __ns:=/ --params-file /tmp/launch_params_0yrvmlvl'].
  ```

## Changes
Before using `fix.latitude` and `fix.longitude`, check for NaN and clear the fields if detected.