### PR TITLE
fix: retry indefinitely on network loss instead of exiting node

### DIFF
--- a/src/ntrip_client/ntrip_base.py
+++ b/src/ntrip_client/ntrip_base.py
@@ -46,22 +46,16 @@ class NTRIPBase:
     raise NotImplementedError("Must override disconnect")
 
   def reconnect(self):
-    if self._connected:
-      while not self._shutdown:
-        self._reconnect_attempt_count += 1
-        self.disconnect()
-        connect_success = self.connect()
-        if not connect_success and self._reconnect_attempt_count < self.reconnect_attempt_max:
-          self._logerr('Reconnect failed. Retrying in {} seconds'.format(self.reconnect_attempt_wait_seconds))
-          time.sleep(self.reconnect_attempt_wait_seconds)
-        elif self._reconnect_attempt_count >= self.reconnect_attempt_max:
-          self._reconnect_attempt_count = 0
-          raise Exception("Reconnect was attempted {} times, but never succeeded".format(self._reconnect_attempt_count))
-        elif connect_success:
-          self._reconnect_attempt_count = 0
-          break
-    else:
-      self._logdebug('Reconnect called while not connected, ignoring')
+    self.disconnect()
+    while not self._shutdown:
+      self._reconnect_attempt_count += 1
+      connect_success = self.connect()
+      if connect_success:
+        self._reconnect_attempt_count = 0
+        break
+      self._logerr('Reconnect attempt {} failed. Retrying in {} seconds'.format(
+        self._reconnect_attempt_count, self.reconnect_attempt_wait_seconds))
+      time.sleep(self.reconnect_attempt_wait_seconds)
 
   def send_nmea(self):
     raise NotImplementedError("Must override send_nmea")

--- a/src/ntrip_client/ntrip_ros_base.py
+++ b/src/ntrip_client/ntrip_ros_base.py
@@ -82,10 +82,16 @@ class NTRIPRosBase:
     # Setup a shutdown hook
     rospy.on_shutdown(self.stop)
 
-    # Connect the client
-    if not self._client.connect():
-      rospy.logerr('Unable to connect to NTRIP server')
-      return 1
+    # Retry initial connection indefinitely until wifi/network is available
+    while not rospy.is_shutdown():
+      if self._client.connect():
+        break
+      rospy.logwarn('Unable to connect to NTRIP server, retrying in {} seconds...'.format(
+        self._reconnect_attempt_wait_seconds))
+      rospy.sleep(self._reconnect_attempt_wait_seconds)
+
+    if rospy.is_shutdown():
+      return 0
 
     # Setup our subscriber
     self._nmea_sub = rospy.Subscriber('nmea', Sentence, self.subscribe_nmea, queue_size=10)


### PR DESCRIPTION
fix: retry indefinitely on network loss instead of exiting node

Two bugs caused the NTRIP client to become unrecoverable when network
was unavailable at startup or dropped mid-session:

1. ntrip_ros_base.py: run() called connect() once and returned 1 on
   failure, causing sys.exit() and killing the ROS node. Now retries
   indefinitely using reconnect_attempt_wait_seconds between attempts.

2. ntrip_base.py: reconnect() raised an Exception after
   reconnect_attempt_max failures, killing the node. The _connected
   guard also caused reconnect() to silently do nothing if called while
   disconnected. Now retries indefinitely with no exception and always
   disconnects cleanly before attempting reconnect.

This allows the node to survive transient network outages (e.g. WiFi
not available at launch) and reconnect seamlessly when connectivity
is restored, without requiring a manual relaunch.